### PR TITLE
Move from rbnacl-libsodium to rbnacl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ services:
 language: ruby
 rvm:
   - 2.3.1
-before_install: gem install bundler -v 1.13.6
+before_install:
+  # travis-ci doesn't include libsodium.
+  - sudo add-apt-repository  ppa:chris-lea/libsodium -y
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libsodium-dev
+  - gem install bundler -v 1.13.6
 script: bin/cibuild
 notifications:
   email: false

--- a/git_hub_integration.gemspec
+++ b/git_hub_integration.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "jwt"
+  spec.add_dependency "jwt", "1.5.1"
   spec.add_dependency "octokit", "4.6.2"
   spec.add_dependency "rbnacl-libsodium"
   spec.add_dependency "redis"

--- a/git_hub_integration.gemspec
+++ b/git_hub_integration.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "jwt", "1.5.1"
   spec.add_dependency "octokit", "4.6.2"
-  spec.add_dependency "rbnacl-libsodium"
+  spec.add_dependency "rbnacl", "~> 5.0"
   spec.add_dependency "redis"
 
   spec.add_development_dependency "bundler"

--- a/lib/git_hub_integration.rb
+++ b/lib/git_hub_integration.rb
@@ -1,11 +1,12 @@
 require "active_support/time"
 require "base64"
+require "git_hub_integration/rbnacl_monkey_patch"
 require "git_hub_integration/token_encryption"
 require "git_hub_integration/version"
 require "json"
 require "jwt"
 require "octokit"
-require "rbnacl/libsodium"
+require "rbnacl"
 require "redis"
 
 # Github authentication

--- a/lib/git_hub_integration/rbnacl_monkey_patch.rb
+++ b/lib/git_hub_integration/rbnacl_monkey_patch.rb
@@ -1,0 +1,17 @@
+module RbNaCl
+  # MonkeyPatch to detect libsodium because ffi won't do it for us
+  module Libsodium
+    class << self
+      def lib_path
+        "/usr/lib/x86_64-linux-gnu"
+      end
+
+      def detect_libsodium_on_heroku
+        Dir.glob(File.join(lib_path, "libsodium*.so.*")).first
+      end
+    end
+    if detect_libsodium_on_heroku.present?
+      ::RBNACL_LIBSODIUM_GEM_LIB_PATH = detect_libsodium_on_heroku
+    end
+  end
+end

--- a/lib/git_hub_integration/version.rb
+++ b/lib/git_hub_integration/version.rb
@@ -1,3 +1,3 @@
 module GitHubIntegration
-  VERSION = "0.1.1".freeze
+  VERSION = "0.1.2".freeze
 end


### PR DESCRIPTION
`rbnacl-libsodium` is being deprecated, so this moves the gem to require `rbnacl` only.
https://github.com/crypto-rb/rbnacl-libsodium/issues/29

`libsodium` now needs to be installed at the OS level (available on `heroku-16` and above).