### PR TITLE
Make expiry checks friendly without active support helpers

### DIFF
--- a/git_hub_integration.gemspec
+++ b/git_hub_integration.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "git_hub_integration/version"
@@ -40,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "0.47.1"
+  spec.add_development_dependency "rubocop", "0.48.1"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "webmock"
 end

--- a/lib/git_hub_integration.rb
+++ b/lib/git_hub_integration.rb
@@ -38,8 +38,14 @@ module GitHubIntegration
     decrypted_access_token
   end
 
-  def self.expired?
+  def self.expires_at
     expires_at = redis.get(EXPIRATION_KEY)
+    if expires_at
+      Time.parse(expires_at)
+    end
+  end
+
+  def self.expired?
     !expires_at || 2.minutes.from_now.utc >= expires_at
   end
 

--- a/lib/git_hub_integration.rb
+++ b/lib/git_hub_integration.rb
@@ -40,9 +40,8 @@ module GitHubIntegration
 
   def self.expires_at
     expires_at = redis.get(EXPIRATION_KEY)
-    if expires_at
-      Time.parse(expires_at)
-    end
+    return unless expires_at
+    Time.parse(expires_at)
   end
 
   def self.expired?

--- a/lib/git_hub_integration/version.rb
+++ b/lib/git_hub_integration/version.rb
@@ -1,3 +1,3 @@
 module GitHubIntegration
-  VERSION = "0.1.2".freeze
+  VERSION = "0.1.3".freeze
 end


### PR DESCRIPTION
Using this gem outside of rails yields a bunch of `ArgumentError: comparison of Time with String failed` exceptions when you try it in a testing environment.