### PR TITLE
Update installation access token route

### DIFF
--- a/lib/git_hub_integration.rb
+++ b/lib/git_hub_integration.rb
@@ -50,7 +50,7 @@ module GitHubIntegration
 
   def self.set_fresh_github_access_token
     response = Octokit.client.post(
-      "/installations/#{github_installation_id}/access_tokens",
+      "/app/installations/#{github_installation_id}/access_tokens",
       headers: {
         "Authorization" => "Bearer #{github_access_token_jwt}",
         "Accept" => "application/vnd.github.machine-man-preview+json"

--- a/lib/git_hub_integration/version.rb
+++ b/lib/git_hub_integration/version.rb
@@ -1,3 +1,3 @@
 module GitHubIntegration
-  VERSION = "0.1.3".freeze
+  VERSION = "0.1.4".freeze
 end

--- a/spec/support/webmock_helpers.rb
+++ b/spec/support/webmock_helpers.rb
@@ -12,7 +12,7 @@ module WebmockHelpers
 
   def stub_github_integration_request(body = nil)
     body ||= { token: "123" }.to_json
-    url = "https://api.github.com/installations/1/access_tokens"
+    url = "https://api.github.com/app/installations/1/access_tokens"
     stub_json_request(:post, url, body)
   end
 end


### PR DESCRIPTION
GitHub is deprecating the endpoint we're using to create an installation
token:
https://developer.github.com/changes/2018-08-16-renaming-and-deprecation-of-github-app-installation-access-token-route/

This PR updates the route.