### PR TITLE
Bump JWT dependency

### DIFF
--- a/git_hub_integration.gemspec
+++ b/git_hub_integration.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "jwt", "1.5.1"
+  spec.add_dependency "jwt", "~> 2"
   spec.add_dependency "octokit", "4.6.2"
   spec.add_dependency "rbnacl", "~> 5.0"
   spec.add_dependency "redis"


### PR DESCRIPTION
Allow for a newer version of JWT.

i also think this justifies a bump of `git_hub_integration` to `0.2.0`?
wdyt?