### PR TITLE
Deprecate active support as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,16 @@ Use of `GitHubIntegration.legacy_client` will allow you to use a Legacy API clie
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. 
+
+### Releasing
+
+1. Update the version number in lib/git_hub_integration/version.rb
+1. Build and Publish the gem
+    1. Run `gem_push=no bundle exec rake release`
+    1. Run `package_cloud push heroku/gemgate pkg/git_hub_integration-x.x.x.gem`
+
+Note: IF you don't have packagecloud setup refer to the [documentation](https://packagecloud.io/docs#cli_install)
 
 ## Contributing
 

--- a/lib/git_hub_integration/version.rb
+++ b/lib/git_hub_integration/version.rb
@@ -1,3 +1,3 @@
 module GitHubIntegration
-  VERSION = "0.2.3".freeze
+  VERSION = "0.3.0".freeze
 end


### PR DESCRIPTION
Used functionality within gem replaced as non breaking change
however other apps consuming the gem may depend on activesupport
without explicitly defining it that could be a breaking change