### PR TITLE
Fix core extension loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem

--- a/lib/git_hub_integration.rb
+++ b/lib/git_hub_integration.rb
@@ -1,4 +1,6 @@
-require "git_hub_integration/core_ext/numeric"
+unless defined?(ActiveSupport::Duration)
+  require "git_hub_integration/core_ext/numeric"
+end
 require "base64"
 require "git_hub_integration/token_encryption"
 require "git_hub_integration/version"

--- a/lib/git_hub_integration/version.rb
+++ b/lib/git_hub_integration/version.rb
@@ -1,3 +1,3 @@
 module GitHubIntegration
-  VERSION = "0.4.0".freeze
+  VERSION = "0.4.1".freeze
 end


### PR DESCRIPTION
When `ActiveSupport` is present in the app, we do not need to load our core extension. This issue popped up in #20 .