### PR TITLE
Fix edge case where Redis returns an empty string

### DIFF
--- a/lib/git_hub_integration.rb
+++ b/lib/git_hub_integration.rb
@@ -39,7 +39,7 @@ module GitHubIntegration
 
   def self.expires_at
     expires_at = redis.get(expiration_key)
-    return unless expires_at
+    return unless expires_at && !expires_at.empty?
     Time.parse(expires_at)
   end
 

--- a/lib/git_hub_integration/version.rb
+++ b/lib/git_hub_integration/version.rb
@@ -1,3 +1,3 @@
 module GitHubIntegration
-  VERSION = "0.4.2".freeze
+  VERSION = "0.4.3".freeze
 end

--- a/spec/git_hub_integration_spec.rb
+++ b/spec/git_hub_integration_spec.rb
@@ -49,6 +49,14 @@ describe GitHubIntegration do
     expect(decrypted_value).to eql("test")
   end
 
+  it "returns nil if Redis returns an empty string or the key does not exist" do
+    expect(GitHubIntegration).to receive(:redis).and_return(double(get: ""))
+    expect(GitHubIntegration.expires_at).to be_nil
+
+    expect(GitHubIntegration).to receive(:redis).and_return(double(get: nil))
+    expect(GitHubIntegration.expires_at).to be_nil
+  end
+
   describe "fetching GitHub App tokens" do
     describe ".github_integration_id" do
       it "should fetch from the environment variable GITHUB_INTEGRATION_ID and cast it as an integer if set" do


### PR DESCRIPTION
During the TPS test suite for some reason I am getting an empty string back from Redis. Cleaning this up to handle those edge cases and adding some testing around it.

Also bumps to `0.4.3`.