### PR TITLE
@W-12623874 optional ssl verification bypass for redis

### DIFF
--- a/lib/git_hub_integration.rb
+++ b/lib/git_hub_integration.rb
@@ -93,7 +93,7 @@ module GitHubIntegration
   def self.redis
     @redis ||= Redis.new(
       url: ENV["REDIS_URL"],
-      ssl_params: ENV["REDIS_OPENSSL_VERIFY_MODE"] == "none" ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+      ssl_params: { verify_mode: ENV["REDIS_OPENSSL_VERIFY_MODE"] == "none" ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER }
     )
   end
 

--- a/lib/git_hub_integration.rb
+++ b/lib/git_hub_integration.rb
@@ -91,7 +91,10 @@ module GitHubIntegration
   end
 
   def self.redis
-    @redis ||= Redis.new(url: ENV["REDIS_URL"])
+    @redis ||= Redis.new(
+      url: ENV["REDIS_URL"],
+      ssl_params: ENV["REDIS_OPENSSL_VERIFY_MODE"] == "none" ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+    )
   end
 
   def self.access_token_key

--- a/spec/git_hub_integration_spec.rb
+++ b/spec/git_hub_integration_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require 'redis'
 
 describe GitHubIntegration do
   it "has a version number" do

--- a/spec/git_hub_integration_spec.rb
+++ b/spec/git_hub_integration_spec.rb
@@ -125,11 +125,15 @@ describe GitHubIntegration do
   end
 
   describe "redis" do
+    before do
+      described_class.instance_variable_set(:@redis, nil)
+    end
+
     context "when REDIS_OPENSSL_VERIFY_MODE is set to 'none'" do
       it "creates a new Redis instance with ssl_params set to VERIFY_NONE" do
         with_environment("REDIS_OPENSSL_VERIFY_MODE" => 'none') do
           redis = described_class.redis # Should use the environment variable during instantiation.
-          expect(redis.client.options[:ssl_params][:verify_mode]).to eq(OpenSSL::SSL::VERIFY_NONE)
+          expect(redis.instance_variable_get(:@options)[:ssl_params][:verify_mode]).to eq(OpenSSL::SSL::VERIFY_NONE)
         end
       end
     end
@@ -138,7 +142,7 @@ describe GitHubIntegration do
       it "creates a new Redis instance with default ssl_params" do
         with_environment("REDIS_OPENSSL_VERIFY_MODE" => nil) do
           redis = described_class.redis # Should use the environment variable during instantiation.
-          expect(redis.client.options[:ssl_params][:verify_mode]).to eq(OpenSSL::SSL::VERIFY_PEER)
+          expect(redis.instance_variable_get(:@options)[:ssl_params][:verify_mode]).to eq(OpenSSL::SSL::VERIFY_PEER)
         end
       end
     end

--- a/spec/git_hub_integration_spec.rb
+++ b/spec/git_hub_integration_spec.rb
@@ -131,7 +131,7 @@ describe GitHubIntegration do
 
     context "when REDIS_OPENSSL_VERIFY_MODE is set to 'none'" do
       it "creates a new Redis instance with ssl_params set to VERIFY_NONE" do
-        with_environment("REDIS_OPENSSL_VERIFY_MODE" => 'none') do
+        with_environment("REDIS_OPENSSL_VERIFY_MODE" => "none") do
           redis = described_class.redis # Should use the environment variable during instantiation.
           expect(redis.instance_variable_get(:@options)[:ssl_params][:verify_mode]).to eq(OpenSSL::SSL::VERIFY_NONE)
         end

--- a/spec/git_hub_integration_spec.rb
+++ b/spec/git_hub_integration_spec.rb
@@ -129,7 +129,7 @@ describe GitHubIntegration do
       it "creates a new Redis instance with ssl_params set to VERIFY_NONE" do
         with_environment("REDIS_OPENSSL_VERIFY_MODE" => 'none') do
           redis = described_class.redis # Should use the environment variable during instantiation.
-          expect(redis.client.ssl_params[:verify_mode]).to eq(OpenSSL::SSL::VERIFY_NONE)
+          expect(redis.client.options[:ssl_params][:verify_mode]).to eq(OpenSSL::SSL::VERIFY_NONE)
         end
       end
     end
@@ -138,7 +138,7 @@ describe GitHubIntegration do
       it "creates a new Redis instance with default ssl_params" do
         with_environment("REDIS_OPENSSL_VERIFY_MODE" => nil) do
           redis = described_class.redis # Should use the environment variable during instantiation.
-          expect(redis.client.ssl_params[:verify_mode]).to eq(OpenSSL::SSL::VERIFY_PEER)
+          expect(redis.client.options[:ssl_params][:verify_mode]).to eq(OpenSSL::SSL::VERIFY_PEER)
         end
       end
     end

--- a/spec/git_hub_integration_spec.rb
+++ b/spec/git_hub_integration_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'redis'
 
 describe GitHubIntegration do
   it "has a version number" do
@@ -119,6 +120,26 @@ describe GitHubIntegration do
         with_environment("GITHUB_INTEGRATION_APPLICATION_ID" => nil) do
           Thread.current[:github_installation_id] = "789"
           expect(GitHubIntegration.github_installation_id).to eq("789")
+        end
+      end
+    end
+  end
+
+  describe "redis" do
+    context "when REDIS_OPENSSL_VERIFY_MODE is set to 'none'" do
+      it "creates a new Redis instance with ssl_params set to VERIFY_NONE" do
+        with_environment("REDIS_OPENSSL_VERIFY_MODE" => 'none') do
+          redis = described_class.redis # Should use the environment variable during instantiation.
+          expect(redis.client.ssl_params[:verify_mode]).to eq(OpenSSL::SSL::VERIFY_NONE)
+        end
+      end
+    end
+
+    context "when REDIS_OPENSSL_VERIFY_MODE is not set" do
+      it "creates a new Redis instance with default ssl_params" do
+        with_environment("REDIS_OPENSSL_VERIFY_MODE" => nil) do
+          redis = described_class.redis # Should use the environment variable during instantiation.
+          expect(redis.client.ssl_params[:verify_mode]).to eq(OpenSSL::SSL::VERIFY_PEER)
         end
       end
     end


### PR DESCRIPTION
* When using redis 6.2, old redis clients must disable SSL verification.
* Setting REDIS_OPENSSL_VERIFY_MODE to 'none' will do so.
* Leaving it unset or any other value will result in the default behavior of peer verification.

For more context: https://help.heroku.com/HC0F8CUS/redis-connection-issues

https://gus.my.salesforce.com/a07EE00001MEDOUYA5